### PR TITLE
fix: use optical flow levels from config

### DIFF
--- a/include/basalt/optical_flow/patch_optical_flow.h
+++ b/include/basalt/optical_flow/patch_optical_flow.h
@@ -298,7 +298,7 @@ class PatchOpticalFlow : public OpticalFlowBase {
 
       Vector2 pos = kd.corners[i].cast<Scalar>();
 
-      for (int l = 0; l < 4; l++) {
+      for (int l = 0; l <= config.optical_flow_levels; l++) {
         Scalar scale = 1 << l;
         Vector2 pos_scaled = pos / scale;
         p.emplace_back(pyramid->at(0).lvl(l), pos_scaled);


### PR DESCRIPTION
This fixes the hard coding of the pyramid levels for patch optical flow. Instead the correct number of pyramid levels from the config. Great code btw.